### PR TITLE
Add xz archive extraction support

### DIFF
--- a/app/models/remote_archive.rb
+++ b/app/models/remote_archive.rb
@@ -121,6 +121,14 @@ class RemoteArchive
               extract_tar(reader, data_destination)
             end
           end
+        when "application/x-xz"
+          destination = File.join(dir, 'tar')
+          FileUtils.mkdir_p(destination)
+          IO.popen(["xz", "-dc", path], "rb", err: :close) do |xz|
+            Minitar::Reader.open(xz) do |reader|
+              extract_tar(reader, destination)
+            end
+          end
         else
           # not supported
           destination = nil

--- a/test/models/remote_archive_test.rb
+++ b/test/models/remote_archive_test.rb
@@ -61,6 +61,32 @@ class ArchiveTest < ActiveSupport::TestCase
     end
   end
 
+  test "extracts tar.xz file correctly" do
+    archive = RemoteArchive.new("http://example.com/archive.tar.xz")
+
+    Dir.mktmpdir do |dir|
+      tar_path = File.join(dir, "archive-input.tar")
+      dest = archive.working_directory(dir)
+
+      File.open(tar_path, "wb") do |file|
+        Minitar::Writer.open(file) do |tar|
+          tar.add_file_simple("package/README.md", mode: 0644, size: 12) do |io|
+            io.write("hello xz tar")
+          end
+        end
+      end
+      system("xz", "-zk", tar_path)
+      FileUtils.mv("#{tar_path}.xz", dest)
+
+      archive.stubs(:download_file).returns(dest)
+      archive.stubs(:mime_type).returns("application/x-xz")
+
+      destination = archive.extract(dir)
+      assert destination.present?, "Expected extract to return a destination"
+      assert_equal "hello xz tar", File.read(File.join(destination, "README.md"))
+    end
+  end
+
   test "returns nil for files larger than 100MB" do
     archive = RemoteArchive.new("http://example.com/base62.tgz")
 


### PR DESCRIPTION
## Summary

Adds support for extracting `application/x-xz` archives by piping the file through `xz -dc` and feeding the decompressed tar stream into the existing safe tar extraction path.

## Testing

- Installed Ruby 4.0.3 tooling required by the repo locally.
- Installed missing native build dependencies `cmake` and `libidn` to complete `bundle install`.
- `bundle exec rails test test/models/remote_archive_test.rb`

Result: 14 runs, 25 assertions, 0 failures, 0 errors.

Fixes #290