### PR TITLE
Add xz archive extraction support

### DIFF
--- a/app/models/remote_archive.rb
+++ b/app/models/remote_archive.rb
@@ -3,6 +3,7 @@ require 'fileutils'
 require 'zip'
 require 'zlib'
 require 'minitar'
+require 'open3'
 
 class RemoteArchive
   attr_accessor :url
@@ -121,6 +122,10 @@ class RemoteArchive
               extract_tar(reader, data_destination)
             end
           end
+        when "application/x-xz"
+          destination = File.join(dir, 'tar')
+          FileUtils.mkdir_p(destination)
+          extract_xz_tar(path, destination)
         else
           # not supported
           destination = nil
@@ -340,6 +345,19 @@ class RemoteArchive
   end
 
   private
+
+  def extract_xz_tar(path, destination)
+    Open3.popen3('xz', '-dc', path) do |_stdin, stdout, stderr, wait_thr|
+      Minitar::Reader.open(stdout) do |reader|
+        extract_tar(reader, destination)
+      end
+
+      unless wait_thr.value.success?
+        Rails.logger.warn("Failed to decompress xz archive: #{stderr.read}")
+        raise "Failed to decompress xz archive"
+      end
+    end
+  end
 
   def extract_tar(reader, destination)
     file_count = 0

--- a/test/models/remote_archive_test.rb
+++ b/test/models/remote_archive_test.rb
@@ -61,6 +61,35 @@ class ArchiveTest < ActiveSupport::TestCase
     end
   end
 
+
+  test "extracts tar.xz file correctly" do
+    archive = RemoteArchive.new("http://example.com/project.tar.xz")
+
+    Dir.mktmpdir do |dir|
+      tar_path = File.join(dir, "project.tar")
+      xz_path = archive.working_directory(dir)
+
+      File.open(tar_path, "wb") do |file|
+        Minitar::Writer.open(file) do |tar|
+          tar.add_file_simple("project/README.md", :mode => 0644, :size => 11) do |io|
+            io.write("hello world")
+          end
+        end
+      end
+
+      system("xz", "-z", "-c", tar_path, out: xz_path)
+
+      archive.stubs(:download_file).returns(xz_path)
+      archive.stubs(:mime_type).with(xz_path).returns("application/x-xz")
+
+      destination = archive.extract(dir)
+      assert destination.present?, "Expected extract to return a destination"
+      files = Dir.glob("**/*", base: destination)
+      assert_includes files, "README.md"
+      assert_equal "hello world", File.read(File.join(destination, "README.md"))
+    end
+  end
+
   test "returns nil for files larger than 100MB" do
     archive = RemoteArchive.new("http://example.com/base62.tgz")
 


### PR DESCRIPTION
## Summary
- add support for extracting `application/x-xz` archives
- stream xz decompression through `xz -dc` into the existing tar extraction path
- add a regression test that builds a `.tar.xz` archive and verifies extracted contents

Refs #290

## Validation
- `ruby -c app/models/remote_archive.rb`
- `ruby -c test/models/remote_archive_test.rb`
- `git diff --check`

I attempted `bundle exec ruby -Itest test/models/remote_archive_test.rb`, but local execution is blocked because the lockfile requires Bundler 4.0.10, while the system Ruby is 2.6.10 and Bundler 4 requires Ruby >= 3.2.0.