### PR TITLE
Return binary archive contents as base64

### DIFF
--- a/app/models/remote_archive.rb
+++ b/app/models/remote_archive.rb
@@ -1,3 +1,4 @@
+require 'base64'
 require 'timeout'
 require 'fileutils'
 require 'zip'
@@ -196,21 +197,24 @@ class RemoteArchive
 
         mime = mime_type(full_path)
 
-        # Check if it's a binary file that can't be encoded as UTF-8
-        unless mime.start_with?('text/') || mime.include?('json') || mime.include?('xml') || mime.include?('javascript') || mime == 'application/octet-stream'
+        raw_contents = File.binread(full_path)
+
+        if binary_file?(mime, raw_contents)
           return {
             name: file_path,
             directory: false,
             binary: true,
             mime_type: mime,
-            error: "Binary file detected. Cannot display contents as text."
+            encoding: 'base64',
+            size: raw_contents.bytesize,
+            contents: Base64.strict_encode64(raw_contents)
           }
         end
 
-        raw_contents = File.read(full_path)
         return {
           name: file_path,
           directory: false,
+          mime_type: mime,
           contents: raw_contents.force_encoding('UTF-8').scrub('�')
         }
       rescue Errno::EISDIR
@@ -224,6 +228,12 @@ class RemoteArchive
         return nil
       end
     end   
+  end
+
+  def binary_file?(mime, contents)
+    return false if mime.start_with?('text/') || mime.include?('json') || mime.include?('xml') || mime.include?('javascript')
+
+    contents.force_encoding('UTF-8').invalid_encoding? || contents.include?("\x00")
   end
 
   def supported_readme_format?(path)


### PR DESCRIPTION
Refs #138

Allows the archives contents endpoint to return binary files safely instead of erroring.

Changes:
- Reads file contents in binary mode
- Detects binary payloads by MIME and content checks
- Returns binary files as base64 JSON with `binary: true`, `encoding: "base64"`, `mime_type`, and `size`
- Keeps text/json/xml/javascript responses as scrubbed UTF-8 text
- Includes `mime_type` in text responses too

Validation:
- `ruby -c app/models/remote_archive.rb`
- `git diff --check`