### PR TITLE
Support extracting xz-compressed tar archives

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/git-pkgs/markup v0.1.0
 	github.com/go-enry/go-enry/v2 v2.9.6
 	github.com/rs/cors v1.11.1
+	github.com/ulikunitz/xz v0.5.15
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/ulikunitz/xz v0.5.15 h1:9DNdB5s+SgV3bQ2ApL10xRc35ck0DuIX/isZvIk+ubY=
+github.com/ulikunitz/xz v0.5.15/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/yuin/goldmark v1.8.2 h1:kEGpgqJXdgbkhcOgBxkC0X0PmoPG1ZyoZ117rDVp4zE=
 github.com/yuin/goldmark v1.8.2/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=
 golang.org/x/net v0.45.0 h1:RLBg5JKixCy82FtLJpeNlVM0nrSqpCRYzVU1n8kj0tM=

--- a/internal/archive/extract.go
+++ b/internal/archive/extract.go
@@ -12,6 +12,8 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/ulikunitz/xz"
 )
 
 func (a *RemoteArchive) Extract(dir string) (string, error) {
@@ -65,6 +67,8 @@ func (a *RemoteArchive) doExtract(path, dir string) (string, error) {
 		return extractZip(path, dir)
 	case "application/gzip":
 		return extractTarGz(path, dir)
+	case "application/x-xz":
+		return extractTarXz(path, dir)
 	case "application/x-tar":
 		return extractTar(path, dir)
 	default:
@@ -180,6 +184,26 @@ func extractTarGz(path, dir string) (string, error) {
 	defer gz.Close()
 
 	return destination, extractTarReader(tar.NewReader(gz), destination, true)
+}
+
+func extractTarXz(path, dir string) (string, error) {
+	destination := filepath.Join(dir, "tar")
+	if err := os.MkdirAll(destination, 0755); err != nil {
+		return "", err
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	xzr, err := xz.NewReader(f)
+	if err != nil {
+		return "", fmt.Errorf("opening xz: %w", err)
+	}
+
+	return destination, extractTarReader(tar.NewReader(xzr), destination, true)
 }
 
 func extractTar(path, dir string) (string, error) {

--- a/internal/archive/extract_test.go
+++ b/internal/archive/extract_test.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"sort"
 	"testing"
+
+	"github.com/ulikunitz/xz"
 )
 
 func TestExtractTarGzFixture(t *testing.T) {
@@ -48,6 +50,81 @@ func TestExtractTarGzFixture(t *testing.T) {
 	}
 	if !fileSet["Readme.md"] {
 		t.Error("expected Readme.md in extracted files")
+	}
+}
+
+func TestExtractTarXz(t *testing.T) {
+	a, _ := New("http://example.com/pkg.tar.xz")
+	dir := t.TempDir()
+
+	path := a.WorkingDirectory(dir)
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	xzw, err := xz.NewWriter(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tw := tar.NewWriter(xzw)
+
+	entries := map[string]string{
+		"pkg/README.md":        "hello from xz",
+		"pkg/internal/code.go": "package internal\n",
+	}
+	for name, contents := range entries {
+		header := &tar.Header{
+			Name: name,
+			Mode: 0644,
+			Size: int64(len(contents)),
+		}
+		if err := tw.WriteHeader(header); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := tw.Write([]byte(contents)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := xzw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := detectMimeType(path); got != "application/x-xz" {
+		t.Fatalf("detectMimeType() = %q, want application/x-xz", got)
+	}
+
+	dest, err := a.Extract(dir)
+	if err != nil {
+		t.Fatalf("Extract() error: %v", err)
+	}
+	if dest == "" {
+		t.Fatal("Extract() returned empty destination")
+	}
+
+	files, _ := listAllFiles(dest)
+	sort.Strings(files)
+
+	expected := []string{
+		"README.md",
+		"internal",
+		filepath.Join("internal", "code.go"),
+	}
+	sort.Strings(expected)
+
+	if len(files) != len(expected) {
+		t.Fatalf("got %d files, want %d\ngot:  %v\nwant: %v", len(files), len(expected), files, expected)
+	}
+	for i, f := range files {
+		if f != expected[i] {
+			t.Errorf("files[%d] = %q, want %q", i, f, expected[i])
+		}
 	}
 }
 
@@ -262,7 +339,7 @@ func TestShouldStripTopLevel(t *testing.T) {
 		{[]string{"a.txt", "b.txt"}, false},
 		{[]string{"pkg/a.txt", "other/b.txt"}, false},
 		{[]string{}, false},
-		{[]string{"pkg/"}, false},           // only a root dir, no non-root entries
+		{[]string{"pkg/"}, false},             // only a root dir, no non-root entries
 		{[]string{"pkg/", "pkg/a.txt"}, true}, // root dir plus files inside
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Closes #290.

## Summary
- route `application/x-xz` archives through a new tar.xz extractor
- decode xz content with `github.com/ulikunitz/xz` before reusing the existing tar extraction path
- add a regression test that builds a `.tar.xz` archive, verifies MIME detection, and checks extracted paths after top-level directory stripping

## Tests
- `PATH=/tmp/codex-go-toolchain/go/bin:$PATH go test ./internal/archive`
- `PATH=/tmp/codex-go-toolchain/go/bin:$PATH go test ./...`
- `PATH=/tmp/codex-go-toolchain/go/bin:$PATH go build ./cmd/server`
- `git diff --check`