### PR TITLE
Clean up Go quality issues

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -14,6 +14,12 @@ import (
 	"github.com/ecosyste-ms/archives/internal/telemetry"
 )
 
+const (
+	serverReadTimeout  = 10 * time.Second
+	serverWriteTimeout = 120 * time.Second
+	serverIdleTimeout  = 60 * time.Second
+)
+
 func main() {
 	if err := run(); err != nil {
 		slog.Error("server failed", "error", err)
@@ -92,9 +98,9 @@ func run() error {
 	server := &http.Server{
 		Addr:         ":" + port,
 		Handler:      wrapped,
-		ReadTimeout:  10 * time.Second,
-		WriteTimeout: 120 * time.Second, // long enough for archive download + extraction
-		IdleTimeout:  60 * time.Second,
+		ReadTimeout:  serverReadTimeout,
+		WriteTimeout: serverWriteTimeout,
+		IdleTimeout:  serverIdleTimeout,
 	}
 
 	slog.Info("starting server", "port", port)

--- a/internal/archive/archive.go
+++ b/internal/archive/archive.go
@@ -15,9 +15,12 @@ import (
 )
 
 const (
-	maxFileSize  = 100 * 1024 * 1024 // 100MB
-	maxFileCount = 10_000
-	userAgent    = "archives.ecosyste.ms"
+	directoryMode              os.FileMode = 0o755
+	downloadFileMode           os.FileMode = 0o644
+	maxFileSize                            = 100 * 1024 * 1024 // 100MB
+	maxFileCount                           = 10_000
+	mimeApplicationOctetStream             = "application/octet-stream"
+	userAgent                              = "archives.ecosyste.ms"
 )
 
 type RemoteArchive struct {
@@ -77,9 +80,9 @@ func (a *RemoteArchive) Download(dir string) error {
 	if err != nil {
 		return fmt.Errorf("downloading: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
-	if resp.StatusCode != 200 {
+	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("download failed: HTTP %d", resp.StatusCode)
 	}
 
@@ -93,7 +96,7 @@ func (a *RemoteArchive) Download(dir string) error {
 		return fmt.Errorf("file is larger than 100MB")
 	}
 
-	return os.WriteFile(path, data, 0644)
+	return os.WriteFile(path, data, downloadFileMode)
 }
 
 func (a *RemoteArchive) ListFiles() ([]string, error) {
@@ -101,7 +104,7 @@ func (a *RemoteArchive) ListFiles() ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer os.RemoveAll(dir)
+	defer func() { _ = os.RemoveAll(dir) }()
 
 	if err := a.Download(dir); err != nil {
 		slog.Info("download failed", "error", err)
@@ -134,7 +137,7 @@ func (a *RemoteArchive) Contents(filePath string) (*FileContent, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer os.RemoveAll(dir)
+	defer func() { _ = os.RemoveAll(dir) }()
 
 	if err := a.Download(dir); err != nil {
 		return nil, err
@@ -247,7 +250,7 @@ func listAllFiles(dir string) ([]string, error) {
 func detectMimeType(path string) string {
 	out, err := exec.Command("file", "--brief", "--mime-type", path).Output()
 	if err != nil {
-		return "application/octet-stream"
+		return mimeApplicationOctetStream
 	}
 	return strings.TrimSpace(string(out))
 }
@@ -261,7 +264,7 @@ func isTextMime(mime string) bool {
 			return true
 		}
 	}
-	return mime == "application/octet-stream"
+	return mime == mimeApplicationOctetStream
 }
 
 func scrubUTF8(data []byte) string {

--- a/internal/archive/archive_test.go
+++ b/internal/archive/archive_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"net/http"
-	"os"
 	"path/filepath"
 	"sort"
 	"testing"
@@ -144,9 +143,9 @@ func TestIsTextMime(t *testing.T) {
 
 func TestListAllFiles(t *testing.T) {
 	dir := t.TempDir()
-	os.MkdirAll(filepath.Join(dir, "sub"), 0755)
-	os.WriteFile(filepath.Join(dir, "a.txt"), []byte("a"), 0644)
-	os.WriteFile(filepath.Join(dir, "sub", "b.txt"), []byte("b"), 0644)
+	makeTestDirectory(t, filepath.Join(dir, "sub"))
+	writeTestFile(t, filepath.Join(dir, "a.txt"), []byte("a"))
+	writeTestFile(t, filepath.Join(dir, "sub", "b.txt"), []byte("b"))
 
 	files, err := listAllFiles(dir)
 	if err != nil {

--- a/internal/archive/benchmark_test.go
+++ b/internal/archive/benchmark_test.go
@@ -18,8 +18,10 @@ func BenchmarkExtractTarGz(b *testing.B) {
 	b.ResetTimer()
 	for b.Loop() {
 		dir := b.TempDir()
-		os.WriteFile(a.WorkingDirectory(dir), data, 0644)
-		a.Extract(dir)
+		writeTestFile(b, a.WorkingDirectory(dir), data)
+		if _, err := a.Extract(dir); err != nil {
+			b.Fatal(err)
+		}
 	}
 }
 
@@ -35,8 +37,10 @@ func BenchmarkExtractZip(b *testing.B) {
 	b.ResetTimer()
 	for b.Loop() {
 		dir := b.TempDir()
-		os.WriteFile(a.WorkingDirectory(dir), data, 0644)
-		a.Extract(dir)
+		writeTestFile(b, a.WorkingDirectory(dir), data)
+		if _, err := a.Extract(dir); err != nil {
+			b.Fatal(err)
+		}
 	}
 }
 
@@ -52,8 +56,10 @@ func BenchmarkExtractJar(b *testing.B) {
 	b.ResetTimer()
 	for b.Loop() {
 		dir := b.TempDir()
-		os.WriteFile(a.WorkingDirectory(dir), data, 0644)
-		a.Extract(dir)
+		writeTestFile(b, a.WorkingDirectory(dir), data)
+		if _, err := a.Extract(dir); err != nil {
+			b.Fatal(err)
+		}
 	}
 }
 
@@ -68,12 +74,17 @@ func BenchmarkListFiles(b *testing.B) {
 
 	// Pre-extract once to get the directory
 	dir := b.TempDir()
-	os.WriteFile(a.WorkingDirectory(dir), data, 0644)
-	extractDir, _ := a.Extract(dir)
+	writeTestFile(b, a.WorkingDirectory(dir), data)
+	extractDir, err := a.Extract(dir)
+	if err != nil {
+		b.Fatal(err)
+	}
 
 	b.ResetTimer()
 	for b.Loop() {
-		listAllFiles(extractDir)
+		if _, err := listAllFiles(extractDir); err != nil {
+			b.Fatal(err)
+		}
 	}
 }
 
@@ -87,8 +98,11 @@ func BenchmarkRenderMarkdown(b *testing.B) {
 	a, _ := New("http://example.com/base62-2.0.1.tgz")
 
 	dir := b.TempDir()
-	os.WriteFile(a.WorkingDirectory(dir), data, 0644)
-	extractDir, _ := a.Extract(dir)
+	writeTestFile(b, a.WorkingDirectory(dir), data)
+	extractDir, err := a.Extract(dir)
+	if err != nil {
+		b.Fatal(err)
+	}
 
 	readmeData, err := os.ReadFile(filepath.Join(extractDir, "Readme.md"))
 	if err != nil {
@@ -119,8 +133,8 @@ func BenchmarkScrubUTF8(b *testing.B) {
 
 func BenchmarkShouldStripTopLevel(b *testing.B) {
 	names := []string{
-		"pkg/a.txt", "pkg/b.txt", "pkg/sub/c.txt",
-		"pkg/sub/d.txt", "pkg/sub/e.txt", "pkg/",
+		testPackageFilename, "pkg/b.txt", "pkg/sub/c.txt",
+		"pkg/sub/d.txt", "pkg/sub/e.txt", testPackageDirectory,
 	}
 
 	b.ResetTimer()

--- a/internal/archive/extract.go
+++ b/internal/archive/extract.go
@@ -16,6 +16,8 @@ import (
 	"github.com/ulikunitz/xz"
 )
 
+const extractionTimeout = 30 * time.Second
+
 func (a *RemoteArchive) Extract(dir string) (string, error) {
 	path := a.WorkingDirectory(dir)
 
@@ -29,7 +31,7 @@ func (a *RemoteArchive) Extract(dir string) (string, error) {
 		return "", nil
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), extractionTimeout)
 	defer cancel()
 
 	type result struct {
@@ -79,7 +81,7 @@ func (a *RemoteArchive) doExtract(path, dir string) (string, error) {
 
 func extractZip(path, dir string) (string, error) {
 	destination := filepath.Join(dir, "zip")
-	if err := os.MkdirAll(destination, 0755); err != nil {
+	if err := os.MkdirAll(destination, directoryMode); err != nil {
 		return "", err
 	}
 
@@ -87,7 +89,7 @@ func extractZip(path, dir string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("opening zip: %w", err)
 	}
-	defer r.Close()
+	defer func() { _ = r.Close() }()
 
 	// Check if we should strip a single top-level directory
 	shouldStrip := shouldStripTopLevel(zipEntryNames(r.File))
@@ -127,11 +129,13 @@ func extractZip(path, dir string) (string, error) {
 		}
 
 		if f.FileInfo().IsDir() {
-			os.MkdirAll(entryPath, 0755)
+			if err := os.MkdirAll(entryPath, directoryMode); err != nil {
+				return "", err
+			}
 			continue
 		}
 
-		if err := os.MkdirAll(filepath.Dir(entryPath), 0755); err != nil {
+		if err := os.MkdirAll(filepath.Dir(entryPath), directoryMode); err != nil {
 			return "", err
 		}
 
@@ -153,21 +157,23 @@ func extractZipFile(f *zip.File, dest string) error {
 	if err != nil {
 		return err
 	}
-	defer rc.Close()
+	defer func() { _ = rc.Close() }()
 
 	out, err := os.Create(dest)
 	if err != nil {
 		return err
 	}
-	defer out.Close()
-
-	_, err = io.Copy(out, io.LimitReader(rc, maxDecompressedFileSize))
-	return err
+	_, copyErr := io.Copy(out, io.LimitReader(rc, maxDecompressedFileSize))
+	closeErr := out.Close()
+	if copyErr != nil {
+		return copyErr
+	}
+	return closeErr
 }
 
 func extractTarGz(path, dir string) (string, error) {
 	destination := filepath.Join(dir, "tar")
-	if err := os.MkdirAll(destination, 0755); err != nil {
+	if err := os.MkdirAll(destination, directoryMode); err != nil {
 		return "", err
 	}
 
@@ -175,20 +181,20 @@ func extractTarGz(path, dir string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	gz, err := gzip.NewReader(f)
 	if err != nil {
 		return "", fmt.Errorf("opening gzip: %w", err)
 	}
-	defer gz.Close()
+	defer func() { _ = gz.Close() }()
 
 	return destination, extractTarReader(tar.NewReader(gz), destination, true)
 }
 
 func extractTarXz(path, dir string) (string, error) {
 	destination := filepath.Join(dir, "tar")
-	if err := os.MkdirAll(destination, 0755); err != nil {
+	if err := os.MkdirAll(destination, directoryMode); err != nil {
 		return "", err
 	}
 
@@ -196,7 +202,7 @@ func extractTarXz(path, dir string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	xzr, err := xz.NewReader(f)
 	if err != nil {
@@ -208,7 +214,7 @@ func extractTarXz(path, dir string) (string, error) {
 
 func extractTar(path, dir string) (string, error) {
 	destination := filepath.Join(dir, "tar")
-	if err := os.MkdirAll(destination, 0755); err != nil {
+	if err := os.MkdirAll(destination, directoryMode); err != nil {
 		return "", err
 	}
 
@@ -216,7 +222,7 @@ func extractTar(path, dir string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	// Extract without stripping top level first, since formats like .gem
 	// have flat entries (data.tar.gz, metadata.gz) with no top-level dir.
@@ -232,7 +238,7 @@ func extractTar(path, dir string) (string, error) {
 		}
 
 		innerDestination := filepath.Join(dir, "inner")
-		if err := os.MkdirAll(innerDestination, 0755); err != nil {
+		if err := os.MkdirAll(innerDestination, directoryMode); err != nil {
 			return "", err
 		}
 
@@ -240,13 +246,13 @@ func extractTar(path, dir string) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		defer df.Close()
+		defer func() { _ = df.Close() }()
 
 		gz, err := gzip.NewReader(df)
 		if err != nil {
 			return "", err
 		}
-		defer gz.Close()
+		defer func() { _ = gz.Close() }()
 
 		if err := extractTarReader(tar.NewReader(gz), innerDestination, false); err != nil {
 			return "", err
@@ -274,20 +280,8 @@ func extractTarReader(tr *tar.Reader, destination string, stripTop bool) error {
 			continue
 		}
 
-		components := splitPath(header.Name)
-		if len(components) == 0 {
-			continue
-		}
-
-		var stripped string
-		if stripTop && len(components) > 1 {
-			stripped = filepath.Join(components[1:]...)
-		} else if stripTop {
-			continue
-		} else {
-			stripped = header.Name
-		}
-		if stripped == "" {
+		stripped, ok := strippedTarPath(header.Name, stripTop)
+		if !ok || stripped == "" {
 			continue
 		}
 
@@ -305,24 +299,51 @@ func extractTarReader(tr *tar.Reader, destination string, stripTop bool) error {
 
 		switch header.Typeflag {
 		case tar.TypeDir:
-			os.MkdirAll(destPath, 0755)
+			if err := os.MkdirAll(destPath, directoryMode); err != nil {
+				return err
+			}
 		case tar.TypeReg:
-			if err := os.MkdirAll(filepath.Dir(destPath), 0755); err != nil {
+			if err := extractTarFile(tr, destPath); err != nil {
 				return err
 			}
-			out, err := os.Create(destPath)
-			if err != nil {
-				return err
-			}
-			if _, err := io.Copy(out, io.LimitReader(tr, maxDecompressedFileSize)); err != nil {
-				out.Close()
-				return err
-			}
-			out.Close()
 		}
 	}
 
 	return nil
+}
+
+func strippedTarPath(name string, stripTop bool) (string, bool) {
+	components := splitPath(name)
+	if len(components) == 0 {
+		return "", false
+	}
+
+	switch {
+	case !stripTop:
+		return name, true
+	case len(components) > 1:
+		return filepath.Join(components[1:]...), true
+	default:
+		return "", false
+	}
+}
+
+func extractTarFile(tr *tar.Reader, destPath string) error {
+	if err := os.MkdirAll(filepath.Dir(destPath), directoryMode); err != nil {
+		return err
+	}
+
+	out, err := os.Create(destPath)
+	if err != nil {
+		return err
+	}
+
+	_, copyErr := io.Copy(out, io.LimitReader(tr, maxDecompressedFileSize))
+	closeErr := out.Close()
+	if copyErr != nil {
+		return copyErr
+	}
+	return closeErr
 }
 
 func zipEntryNames(files []*zip.File) []string {

--- a/internal/archive/extract_test.go
+++ b/internal/archive/extract_test.go
@@ -25,7 +25,7 @@ func TestExtractTarGzFixture(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	os.WriteFile(a.WorkingDirectory(dir), data, 0644)
+	writeTestFile(t, a.WorkingDirectory(dir), data)
 
 	dest, err := a.Extract(dir)
 	if err != nil {
@@ -45,7 +45,7 @@ func TestExtractTarGzFixture(t *testing.T) {
 	for _, f := range files {
 		fileSet[f] = true
 	}
-	if !fileSet["package.json"] {
+	if !fileSet[testPackageJSONFilename] {
 		t.Error("expected package.json in extracted files")
 	}
 	if !fileSet["Readme.md"] {
@@ -112,7 +112,7 @@ func TestExtractTarXz(t *testing.T) {
 	sort.Strings(files)
 
 	expected := []string{
-		"README.md",
+		testReadmeFilename,
 		"internal",
 		filepath.Join("internal", "code.go"),
 	}
@@ -138,7 +138,7 @@ func TestExtractZipFixture(t *testing.T) {
 	dir := t.TempDir()
 
 	data, _ := os.ReadFile(fixture)
-	os.WriteFile(a.WorkingDirectory(dir), data, 0644)
+	writeTestFile(t, a.WorkingDirectory(dir), data)
 
 	dest, err := a.Extract(dir)
 	if err != nil {
@@ -154,10 +154,10 @@ func TestExtractZipFixture(t *testing.T) {
 		fileSet[f] = true
 	}
 
-	if !fileSet["README.md"] {
+	if !fileSet[testReadmeFilename] {
 		t.Error("expected README.md in extracted files")
 	}
-	if !fileSet["package.json"] {
+	if !fileSet[testPackageJSONFilename] {
 		t.Error("expected package.json in extracted files")
 	}
 }
@@ -172,7 +172,7 @@ func TestExtractJarFixture(t *testing.T) {
 	dir := t.TempDir()
 
 	data, _ := os.ReadFile(fixture)
-	os.WriteFile(a.WorkingDirectory(dir), data, 0644)
+	writeTestFile(t, a.WorkingDirectory(dir), data)
 
 	dest, err := a.Extract(dir)
 	if err != nil {
@@ -204,7 +204,7 @@ func TestExtractApkFixture(t *testing.T) {
 	dir := t.TempDir()
 
 	data, _ := os.ReadFile(fixture)
-	os.WriteFile(a.WorkingDirectory(dir), data, 0644)
+	writeTestFile(t, a.WorkingDirectory(dir), data)
 
 	dest, err := a.Extract(dir)
 	if err != nil {
@@ -238,7 +238,7 @@ func TestExtractGemFixture(t *testing.T) {
 	dir := t.TempDir()
 
 	data, _ := os.ReadFile(fixture)
-	os.WriteFile(a.WorkingDirectory(dir), data, 0644)
+	writeTestFile(t, a.WorkingDirectory(dir), data)
 
 	dest, err := a.Extract(dir)
 	if err != nil {
@@ -272,9 +272,16 @@ func TestExtractRejectsLargeFile(t *testing.T) {
 
 	// Create a file larger than 100MB
 	path := a.WorkingDirectory(dir)
-	f, _ := os.Create(path)
-	f.Truncate(101 * 1024 * 1024)
-	f.Close()
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Truncate(101 * 1024 * 1024); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
 
 	dest, err := a.Extract(dir)
 	if err != nil {
@@ -290,7 +297,7 @@ func TestExtractRejectsUnsupportedMimeType(t *testing.T) {
 	dir := t.TempDir()
 
 	path := a.WorkingDirectory(dir)
-	os.WriteFile(path, []byte("not an archive"), 0644)
+	writeTestFile(t, path, []byte("not an archive"))
 
 	dest, err := a.Extract(dir)
 	if err != nil {
@@ -308,7 +315,10 @@ func TestExtractBlocksPathTraversal(t *testing.T) {
 	path := a.WorkingDirectory(dir)
 
 	// Create a tar.gz with path traversal
-	f, _ := os.Create(path)
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
 	gw := gzip.NewWriter(f)
 	tw := tar.NewWriter(gw)
 
@@ -318,11 +328,21 @@ func TestExtractBlocksPathTraversal(t *testing.T) {
 		Mode: 0644,
 		Size: 5,
 	}
-	tw.WriteHeader(header)
-	tw.Write([]byte("oops!"))
-	tw.Close()
-	gw.Close()
-	f.Close()
+	if err := tw.WriteHeader(header); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tw.Write([]byte("oops!")); err != nil {
+		t.Fatal(err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
 
 	dest, err := a.Extract(dir)
 	if err == nil && dest != "" {
@@ -335,12 +355,12 @@ func TestShouldStripTopLevel(t *testing.T) {
 		names []string
 		want  bool
 	}{
-		{[]string{"pkg/a.txt", "pkg/b.txt", "pkg/"}, true},
+		{[]string{testPackageFilename, "pkg/b.txt", testPackageDirectory}, true},
 		{[]string{"a.txt", "b.txt"}, false},
-		{[]string{"pkg/a.txt", "other/b.txt"}, false},
+		{[]string{testPackageFilename, "other/b.txt"}, false},
 		{[]string{}, false},
-		{[]string{"pkg/"}, false},             // only a root dir, no non-root entries
-		{[]string{"pkg/", "pkg/a.txt"}, true}, // root dir plus files inside
+		{[]string{testPackageDirectory}, false},                     // only a root dir, no non-root entries
+		{[]string{testPackageDirectory, testPackageFilename}, true}, // root dir plus files inside
 	}
 	for _, tt := range tests {
 		got := shouldStripTopLevel(tt.names)
@@ -385,7 +405,7 @@ func TestExtractTarGzFileList(t *testing.T) {
 	dir := t.TempDir()
 
 	data, _ := os.ReadFile(fixture)
-	os.WriteFile(a.WorkingDirectory(dir), data, 0644)
+	writeTestFile(t, a.WorkingDirectory(dir), data)
 
 	dest, err := a.Extract(dir)
 	if err != nil {
@@ -402,7 +422,7 @@ func TestExtractTarGzFileList(t *testing.T) {
 		".eslintrc",
 		".travis.yml",
 		"CODE_OF_CONDUCT.md",
-		"CONTRIBUTING.md",
+		testContributingFilename,
 		"LICENSE",
 		"Readme.md",
 		"benchmark",
@@ -411,8 +431,8 @@ func TestExtractTarGzFileList(t *testing.T) {
 		"fork",
 		filepath.Join("fork", ".editorconfig"),
 		filepath.Join("fork", ".eslintrc"),
-		filepath.Join("fork", "README.md"),
-		filepath.Join("fork", "package.json"),
+		filepath.Join("fork", testReadmeFilename),
+		filepath.Join("fork", testPackageJSONFilename),
 		filepath.Join("fork", "src"),
 		filepath.Join("fork", "src", "ascii.js"),
 		filepath.Join("fork", "src", "custom.js"),
@@ -424,7 +444,7 @@ func TestExtractTarGzFileList(t *testing.T) {
 		filepath.Join("lib", "ascii.js"),
 		filepath.Join("lib", "custom.js"),
 		filepath.Join("lib", "legacy.js"),
-		"package.json",
+		testPackageJSONFilename,
 		"test",
 		filepath.Join("test", "test_ascii.js"),
 		filepath.Join("test", "test_custom.js"),
@@ -454,7 +474,7 @@ func TestExtractZipFileList(t *testing.T) {
 	dir := t.TempDir()
 
 	data, _ := os.ReadFile(fixture)
-	os.WriteFile(a.WorkingDirectory(dir), data, 0644)
+	writeTestFile(t, a.WorkingDirectory(dir), data)
 
 	dest, err := a.Extract(dir)
 	if err != nil {
@@ -478,11 +498,11 @@ func TestExtractZipFileList(t *testing.T) {
 		".snyk",
 		"CHANGELOG.md",
 		"CODE_OF_CONDUCT.md",
-		"CONTRIBUTING.md",
+		testContributingFilename,
 		"LICENSE.txt",
-		"README.md",
+		testReadmeFilename,
 		"package-lock.json",
-		"package.json",
+		testPackageJSONFilename,
 		"src",
 		filepath.Join("src", "HTLAsset.js"),
 		filepath.Join("src", "HelixJSAsset.js"),
@@ -519,7 +539,7 @@ func TestExtractJarFileList(t *testing.T) {
 	dir := t.TempDir()
 
 	data, _ := os.ReadFile(fixture)
-	os.WriteFile(a.WorkingDirectory(dir), data, 0644)
+	writeTestFile(t, a.WorkingDirectory(dir), data)
 
 	dest, err := a.Extract(dir)
 	if err != nil {
@@ -536,7 +556,7 @@ func TestExtractJarFileList(t *testing.T) {
 		filepath.Join("META-INF", "leiningen"),
 		filepath.Join("META-INF", "leiningen", "org.clojars.majorcluster"),
 		filepath.Join("META-INF", "leiningen", "org.clojars.majorcluster", "clj-data-adapter"),
-		filepath.Join("META-INF", "leiningen", "org.clojars.majorcluster", "clj-data-adapter", "README.md"),
+		filepath.Join("META-INF", "leiningen", "org.clojars.majorcluster", "clj-data-adapter", testReadmeFilename),
 		filepath.Join("META-INF", "leiningen", "org.clojars.majorcluster", "clj-data-adapter", "project.clj"),
 		filepath.Join("META-INF", "maven"),
 		filepath.Join("META-INF", "maven", "org.clojars.majorcluster"),

--- a/internal/archive/readme.go
+++ b/internal/archive/readme.go
@@ -45,7 +45,7 @@ func (a *RemoteArchive) Readme() (*ReadmeResult, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer os.RemoveAll(dir)
+	defer func() { _ = os.RemoveAll(dir) }()
 
 	if err := a.Download(dir); err != nil {
 		return nil, err
@@ -129,7 +129,7 @@ func (a *RemoteArchive) Changelog() (*ChangelogResult, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer os.RemoveAll(dir)
+	defer func() { _ = os.RemoveAll(dir) }()
 
 	if err := a.Download(dir); err != nil {
 		return nil, err

--- a/internal/archive/readme_test.go
+++ b/internal/archive/readme_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestRenderFileMarkdown(t *testing.T) {
-	html, lang := renderFile("README.md", []byte("# Hello\n\nWorld **bold** text"))
+	html, lang := renderFile(testReadmeFilename, []byte("# Hello\n\nWorld **bold** text"))
 	if lang != "Markdown" {
 		t.Errorf("language = %q, want Markdown", lang)
 	}
@@ -60,7 +60,7 @@ func TestSupportedReadmeFormats(t *testing.T) {
 		path string
 		want bool
 	}{
-		{"README.md", true},
+		{testReadmeFilename, true},
 		{"README.markdown", true},
 		{"README.textile", true},
 		{"README.org", true},
@@ -85,12 +85,12 @@ func TestReadmePatternMatches(t *testing.T) {
 		name string
 		want bool
 	}{
-		{"README.md", true},
+		{testReadmeFilename, true},
 		{"Readme.md", true},
 		{"readme.txt", true},
 		{"README", true},
-		{"CONTRIBUTING.md", false},
-		{"package.json", false},
+		{testContributingFilename, false},
+		{testPackageJSONFilename, false},
 	}
 	for _, tt := range tests {
 		got := readmePattern.MatchString(tt.name)
@@ -110,8 +110,8 @@ func TestChangelogPatternMatches(t *testing.T) {
 		{"HISTORY.md", true},
 		{"NEWS.md", true},
 		{"changelog.md", true},
-		{"README.md", false},
-		{"package.json", false},
+		{testReadmeFilename, false},
+		{testPackageJSONFilename, false},
 	}
 	for _, tt := range tests {
 		got := changelogPattern.MatchString(tt.name)

--- a/internal/archive/repopack.go
+++ b/internal/archive/repopack.go
@@ -17,7 +17,7 @@ func (a *RemoteArchive) Repopack() (*RepopackResult, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer os.RemoveAll(dir)
+	defer func() { _ = os.RemoveAll(dir) }()
 
 	if err := a.Download(dir); err != nil {
 		return nil, err

--- a/internal/archive/safeclient.go
+++ b/internal/archive/safeclient.go
@@ -10,6 +10,15 @@ import (
 	"github.com/ecosyste-ms/archives/internal/telemetry"
 )
 
+const (
+	dialTimeout           = 30 * time.Second
+	keepAliveInterval     = 30 * time.Second
+	maxRedirects          = 10
+	requestTimeout        = 60 * time.Second
+	responseHeaderTimeout = 30 * time.Second
+	tlsHandshakeTimeout   = 10 * time.Second
+)
+
 // safeClient returns an HTTP client that blocks connections to private,
 // loopback, and link-local IP addresses. This prevents SSRF attacks
 // where a user-supplied URL could reach internal services or cloud
@@ -20,22 +29,22 @@ import (
 // to a public IP but later resolves to a private one.
 func safeClient() *http.Client {
 	dialer := &net.Dialer{
-		Timeout:   30 * time.Second,
-		KeepAlive: 30 * time.Second,
+		Timeout:   dialTimeout,
+		KeepAlive: keepAliveInterval,
 		Control:   blockPrivateIPs,
 	}
 
 	transport := &http.Transport{
 		DialContext:           dialer.DialContext,
-		TLSHandshakeTimeout:  10 * time.Second,
-		ResponseHeaderTimeout: 30 * time.Second,
+		TLSHandshakeTimeout:   tlsHandshakeTimeout,
+		ResponseHeaderTimeout: responseHeaderTimeout,
 	}
 
 	return &http.Client{
 		Transport: telemetry.HTTPTransport(transport),
-		Timeout:   60 * time.Second,
+		Timeout:   requestTimeout,
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
-			if len(via) >= 10 {
+			if len(via) >= maxRedirects {
 				return fmt.Errorf("too many redirects")
 			}
 			return nil

--- a/internal/archive/test_helpers_test.go
+++ b/internal/archive/test_helpers_test.go
@@ -1,0 +1,28 @@
+package archive
+
+import (
+	"os"
+	"testing"
+)
+
+const (
+	testContributingFilename = "CONTRIBUTING.md"
+	testPackageDirectory     = "pkg/"
+	testPackageFilename      = "pkg/a.txt"
+	testPackageJSONFilename  = "package.json"
+	testReadmeFilename       = "README.md"
+)
+
+func makeTestDirectory(tb testing.TB, path string) {
+	tb.Helper()
+	if err := os.MkdirAll(path, directoryMode); err != nil {
+		tb.Fatalf("create test directory: %v", err)
+	}
+}
+
+func writeTestFile(tb testing.TB, path string, data []byte) {
+	tb.Helper()
+	if err := os.WriteFile(path, data, downloadFileMode); err != nil {
+		tb.Fatalf("write test file: %v", err)
+	}
+}

--- a/internal/handler/archives.go
+++ b/internal/handler/archives.go
@@ -21,7 +21,9 @@ func setCacheHeaders(w http.ResponseWriter) {
 func writeJSON(w http.ResponseWriter, status int, v any) {
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	w.WriteHeader(status)
-	json.NewEncoder(w).Encode(v)
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		slog.Error("failed to encode JSON response", "error", err)
+	}
 }
 
 func writeError(w http.ResponseWriter, status int, msg string) {

--- a/internal/handler/benchmark_test.go
+++ b/internal/handler/benchmark_test.go
@@ -14,7 +14,7 @@ func setupBenchmarkFixtureServer(b *testing.B) *httptest.Server {
 
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fixtures := map[string]string{
-			"/base62/-/base62-2.0.1.tgz":                            "base62-2.0.1.tgz",
+			"/base62/-/base62-2.0.1.tgz":                             "base62-2.0.1.tgz",
 			"/adobe/parcel-plugin-htl/archive/refs/heads/master.zip": "parcel-plugin-htl-master.zip",
 			"/splitrb/split/archive/refs/heads/main.zip":             "main.zip",
 		}
@@ -30,7 +30,7 @@ func setupBenchmarkFixtureServer(b *testing.B) *httptest.Server {
 			http.Error(w, err.Error(), 500)
 			return
 		}
-		w.Write(data)
+		_, _ = w.Write(data)
 	}))
 }
 
@@ -124,7 +124,9 @@ func BenchmarkHandleHomeHTML(b *testing.B) {
 	if _, err := os.Stat(templateDir); os.IsNotExist(err) {
 		b.Skip("templates directory not found")
 	}
-	InitTemplates(templateDir)
+	if err := InitTemplates(templateDir); err != nil {
+		b.Fatal(err)
+	}
 
 	b.ResetTimer()
 	for b.Loop() {

--- a/internal/handler/docs.go
+++ b/internal/handler/docs.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"log/slog"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -22,7 +23,9 @@ func (d *DocsHandler) HandleOpenAPISpec(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	w.Header().Set("Content-Type", "application/yaml")
-	w.Write(data)
+	if _, err := w.Write(data); err != nil {
+		slog.Error("failed to write OpenAPI response", "error", err)
+	}
 }
 
 func RedirectDocs(w http.ResponseWriter, r *http.Request) {
@@ -31,7 +34,9 @@ func RedirectDocs(w http.ResponseWriter, r *http.Request) {
 
 func (d *DocsHandler) HandleDocs(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	w.Write([]byte(swaggerUIHTML))
+	if _, err := w.Write([]byte(swaggerUIHTML)); err != nil {
+		slog.Error("failed to write API documentation response", "error", err)
+	}
 }
 
 const swaggerUIHTML = `<!DOCTYPE html>

--- a/internal/handler/handler_test.go
+++ b/internal/handler/handler_test.go
@@ -28,10 +28,10 @@ func setupFixtureServer(t *testing.T) *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Map URL paths to fixture files
 		fixtures := map[string]string{
-			"/base62/-/base62-2.0.1.tgz":                                          "base62-2.0.1.tgz",
-			"/adobe/parcel-plugin-htl/archive/refs/heads/master.zip":               "parcel-plugin-htl-master.zip",
+			"/base62/-/base62-2.0.1.tgz":                                                  "base62-2.0.1.tgz",
+			"/adobe/parcel-plugin-htl/archive/refs/heads/master.zip":                      "parcel-plugin-htl-master.zip",
 			"/org/clojars/majorcluster/clj-data-adapter/0.2.1/clj-data-adapter-0.2.1.jar": "clj-data-adapter-0.2.1.jar",
-			"/splitrb/split/archive/refs/heads/main.zip":                           "main.zip",
+			"/splitrb/split/archive/refs/heads/main.zip":                                  "main.zip",
 		}
 
 		filename, ok := fixtures[r.URL.Path]
@@ -45,8 +45,15 @@ func setupFixtureServer(t *testing.T) *httptest.Server {
 			http.Error(w, err.Error(), 500)
 			return
 		}
-		w.Write(data)
+		_, _ = w.Write(data)
 	}))
+}
+
+func decodeResponse(t *testing.T, w *httptest.ResponseRecorder, value any) {
+	t.Helper()
+	if err := json.NewDecoder(w.Body).Decode(value); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
 }
 
 func TestHandleListTarGz(t *testing.T) {
@@ -64,7 +71,7 @@ func TestHandleListTarGz(t *testing.T) {
 	}
 
 	var files []string
-	json.NewDecoder(w.Body).Decode(&files)
+	decodeResponse(t, w, &files)
 
 	fileSet := make(map[string]bool)
 	for _, f := range files {
@@ -97,7 +104,7 @@ func TestHandleListZip(t *testing.T) {
 	}
 
 	var files []string
-	json.NewDecoder(w.Body).Decode(&files)
+	decodeResponse(t, w, &files)
 
 	fileSet := make(map[string]bool)
 	for _, f := range files {
@@ -127,7 +134,7 @@ func TestHandleListJar(t *testing.T) {
 	}
 
 	var files []string
-	json.NewDecoder(w.Body).Decode(&files)
+	decodeResponse(t, w, &files)
 
 	fileSet := make(map[string]bool)
 	for _, f := range files {
@@ -154,7 +161,7 @@ func TestHandleContentsFile(t *testing.T) {
 	}
 
 	var result map[string]any
-	json.NewDecoder(w.Body).Decode(&result)
+	decodeResponse(t, w, &result)
 
 	if result["name"] != ".eslintignore" {
 		t.Errorf("expected name .eslintignore, got %v", result["name"])
@@ -183,7 +190,7 @@ func TestHandleContentsFolder(t *testing.T) {
 	}
 
 	var result map[string]any
-	json.NewDecoder(w.Body).Decode(&result)
+	decodeResponse(t, w, &result)
 
 	if result["name"] != "lib" {
 		t.Errorf("expected name lib, got %v", result["name"])
@@ -236,7 +243,7 @@ func TestHandleReadme(t *testing.T) {
 	}
 
 	var result map[string]any
-	json.NewDecoder(w.Body).Decode(&result)
+	decodeResponse(t, w, &result)
 
 	if result["name"] != "Readme.md" {
 		t.Errorf("expected name Readme.md, got %v", result["name"])
@@ -284,7 +291,7 @@ func TestHandleChangelog(t *testing.T) {
 	}
 
 	var result map[string]any
-	json.NewDecoder(w.Body).Decode(&result)
+	decodeResponse(t, w, &result)
 
 	if result["name"] != "CHANGELOG.md" {
 		t.Errorf("expected name CHANGELOG.md, got %v", result["name"])
@@ -459,7 +466,7 @@ func TestHandleNotFoundJSON(t *testing.T) {
 	}
 
 	var result map[string]string
-	json.NewDecoder(w.Body).Decode(&result)
+	decodeResponse(t, w, &result)
 	if result["error"] != "not found" {
 		t.Errorf("expected error 'not found', got %q", result["error"])
 	}
@@ -470,7 +477,9 @@ func TestHandleNotFoundHTML(t *testing.T) {
 	if _, err := os.Stat(templateDir); os.IsNotExist(err) {
 		t.Skip("templates directory not found")
 	}
-	InitTemplates(templateDir)
+	if err := InitTemplates(templateDir); err != nil {
+		t.Fatal(err)
+	}
 
 	req := httptest.NewRequest("GET", "/nonexistent", nil)
 	req.Header.Set("Accept", "text/html")

--- a/internal/handler/home.go
+++ b/internal/handler/home.go
@@ -5,9 +5,15 @@ import (
 	"encoding/hex"
 	"html/template"
 	"io/fs"
+	"log/slog"
 	"net/http"
 	"os"
 	"path/filepath"
+)
+
+const (
+	appDescription = "An open API service for inspecting package archives and files from many open source software ecosystems. Explore package contents without downloading."
+	appName        = "Archives"
 )
 
 type Format struct {
@@ -16,14 +22,14 @@ type Format struct {
 }
 
 type HomeData struct {
-	Formats          []Format
-	AppName          string
-	AppDescription   string
-	MetaTitle        string
-	MetaDescription  string
-	GithubRepoName   string
-	Services         map[string][]Service
-	RequestBaseURL   string
+	Formats         []Format
+	AppName         string
+	AppDescription  string
+	MetaTitle       string
+	MetaDescription string
+	GithubRepoName  string
+	Services        map[string][]Service
+	RequestBaseURL  string
 }
 
 type Service struct {
@@ -32,15 +38,15 @@ type Service struct {
 }
 
 type ErrorData struct {
-	AppName          string
-	AppDescription   string
-	MetaTitle        string
-	MetaDescription  string
-	GithubRepoName   string
-	Services         map[string][]Service
-	RequestBaseURL   string
-	StatusCode       int
-	StatusText       string
+	AppName         string
+	AppDescription  string
+	MetaTitle       string
+	MetaDescription string
+	GithubRepoName  string
+	Services        map[string][]Service
+	RequestBaseURL  string
+	StatusCode      int
+	StatusText      string
 }
 
 var formats = []Format{
@@ -64,7 +70,7 @@ var services = map[string][]Service{
 		{Name: "SBOM Parser", URL: "https://sbom.ecosyste.ms"},
 		{Name: "License Parser", URL: "https://licenses.ecosyste.ms"},
 		{Name: "Digest", URL: "https://digest.ecosyste.ms"},
-		{Name: "Archives", URL: "https://archives.ecosyste.ms"},
+		{Name: appName, URL: "https://archives.ecosyste.ms"},
 		{Name: "Diff", URL: "https://diff.ecosyste.ms"},
 		{Name: "Summary", URL: "https://summary.ecosyste.ms"},
 	},
@@ -160,17 +166,17 @@ func HandleHome(w http.ResponseWriter, r *http.Request) {
 
 	data := HomeData{
 		Formats:         formats,
-		AppName:         "Archives",
-		AppDescription:  "An open API service for inspecting package archives and files from many open source software ecosystems. Explore package contents without downloading.",
+		AppName:         appName,
+		AppDescription:  appDescription,
 		MetaTitle:       "Ecosyste.ms: Archives",
-		MetaDescription: "An open API service for inspecting package archives and files from many open source software ecosystems. Explore package contents without downloading.",
+		MetaDescription: appDescription,
 		GithubRepoName:  githubRepoName(),
 		Services:        services,
 		RequestBaseURL:  requestBaseURL(r),
 	}
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	templates.ExecuteTemplate(w, "layout.html", data)
+	renderTemplate(w, "layout.html", data)
 }
 
 func HandleNotFound(w http.ResponseWriter, r *http.Request) {
@@ -181,19 +187,19 @@ func HandleNotFound(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := ErrorData{
-		AppName:        "Archives",
-		AppDescription: "An open API service for inspecting package archives and files from many open source software ecosystems. Explore package contents without downloading.",
+		AppName:        appName,
+		AppDescription: appDescription,
 		MetaTitle:      "Not Found | Ecosyste.ms: Archives",
 		GithubRepoName: githubRepoName(),
 		Services:       services,
 		RequestBaseURL: requestBaseURL(r),
-		StatusCode:     404,
+		StatusCode:     http.StatusNotFound,
 		StatusText:     "Not Found",
 	}
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.WriteHeader(http.StatusNotFound)
-	templates.ExecuteTemplate(w, "error.html", data)
+	renderTemplate(w, "error.html", data)
 }
 
 func HandleUnprocessable(w http.ResponseWriter, r *http.Request) {
@@ -204,19 +210,19 @@ func HandleUnprocessable(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := ErrorData{
-		AppName:        "Archives",
-		AppDescription: "An open API service for inspecting package archives and files from many open source software ecosystems. Explore package contents without downloading.",
+		AppName:        appName,
+		AppDescription: appDescription,
 		MetaTitle:      "Unprocessable | Ecosyste.ms: Archives",
 		GithubRepoName: githubRepoName(),
 		Services:       services,
 		RequestBaseURL: requestBaseURL(r),
-		StatusCode:     422,
+		StatusCode:     http.StatusUnprocessableEntity,
 		StatusText:     "Unprocessable Entity",
 	}
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.WriteHeader(http.StatusUnprocessableEntity)
-	templates.ExecuteTemplate(w, "error.html", data)
+	renderTemplate(w, "error.html", data)
 }
 
 func HandleInternalError(w http.ResponseWriter, r *http.Request) {
@@ -227,19 +233,25 @@ func HandleInternalError(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := ErrorData{
-		AppName:        "Archives",
-		AppDescription: "An open API service for inspecting package archives and files from many open source software ecosystems. Explore package contents without downloading.",
+		AppName:        appName,
+		AppDescription: appDescription,
 		MetaTitle:      "Internal Server Error | Ecosyste.ms: Archives",
 		GithubRepoName: githubRepoName(),
 		Services:       services,
 		RequestBaseURL: requestBaseURL(r),
-		StatusCode:     500,
+		StatusCode:     http.StatusInternalServerError,
 		StatusText:     "Internal Server Error",
 	}
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.WriteHeader(http.StatusInternalServerError)
-	templates.ExecuteTemplate(w, "error.html", data)
+	renderTemplate(w, "error.html", data)
+}
+
+func renderTemplate(w http.ResponseWriter, name string, data any) {
+	if err := templates.ExecuteTemplate(w, name, data); err != nil {
+		slog.Error("failed to render template", "name", name, "error", err)
+	}
 }
 
 func isJSONRequest(accept string) bool {


### PR DESCRIPTION
Clean up Go lint findings across archive extraction, HTTP handlers, tests, and benchmarks. Check ignored errors, name repeated values, and split tar extraction into smaller helpers.